### PR TITLE
custom logger

### DIFF
--- a/jsonrpcserver/async_dispatcher.py
+++ b/jsonrpcserver/async_dispatcher.py
@@ -41,7 +41,7 @@ async def call(request: Request, context: Any, method: Method) -> Result:
     except JsonRpcError as exc:
         return Left(ErrorResult(code=exc.code, message=exc.message, data=exc.data))
     except Exception as exc:  # Other error inside method - Internal error
-        logger.error(traceback.format_exc())
+        logger.exception(exc)
         return Left(InternalErrorResult(str(exc)))
     return result
 
@@ -102,5 +102,5 @@ async def dispatch_to_response_pure(
             )
         )
     except Exception as exc:
-        logger.error(traceback.format_exc())
+        logger.exception(exc)
         return post_process(Left(ServerErrorResponse(str(exc), None)))

--- a/jsonrpcserver/async_dispatcher.py
+++ b/jsonrpcserver/async_dispatcher.py
@@ -5,6 +5,7 @@ from itertools import starmap
 from typing import Any, Callable, Iterable, Tuple, Union
 import asyncio
 import logging
+import traceback
 
 from oslash.either import Left  # type: ignore
 
@@ -30,6 +31,8 @@ from .response import Response, ServerErrorResponse
 from .utils import make_list
 
 
+logger = logging.getLogger("jsonrpcserver")
+
 async def call(request: Request, context: Any, method: Method) -> Result:
     try:
         result = await method(
@@ -39,7 +42,7 @@ async def call(request: Request, context: Any, method: Method) -> Result:
     except JsonRpcError as exc:
         return Left(ErrorResult(code=exc.code, message=exc.message, data=exc.data))
     except Exception as exc:  # Other error inside method - Internal error
-        logging.exception(exc)
+        logger.error(traceback.format_exc())
         return Left(InternalErrorResult(str(exc)))
     return result
 
@@ -100,5 +103,5 @@ async def dispatch_to_response_pure(
             )
         )
     except Exception as exc:
-        logging.exception(exc)
+        logger.error(traceback.format_exc())
         return post_process(Left(ServerErrorResponse(str(exc), None)))

--- a/jsonrpcserver/async_dispatcher.py
+++ b/jsonrpcserver/async_dispatcher.py
@@ -5,7 +5,6 @@ from itertools import starmap
 from typing import Any, Callable, Iterable, Tuple, Union
 import asyncio
 import logging
-import traceback
 
 from oslash.either import Left  # type: ignore
 
@@ -31,7 +30,7 @@ from .response import Response, ServerErrorResponse
 from .utils import make_list
 
 
-logger = logging.getLogger("jsonrpcserver")
+logger = logging.getLogger(__name__)
 
 async def call(request: Request, context: Any, method: Method) -> Result:
     try:

--- a/jsonrpcserver/dispatcher.py
+++ b/jsonrpcserver/dispatcher.py
@@ -6,6 +6,7 @@ from inspect import signature
 from itertools import starmap
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Union
 import logging
+import traceback
 
 from oslash.either import Either, Left, Right  # type: ignore
 
@@ -32,6 +33,8 @@ from .sentinels import NOCONTEXT, NOID
 from .utils import compose, make_list
 
 Deserialized = Union[Dict[str, Any], List[Dict[str, Any]]]
+
+logger = logging.getLogger("jsonrpcserver")
 
 
 def extract_list(
@@ -133,7 +136,7 @@ def call(request: Request, context: Any, method: Method) -> Result:
         return Left(ErrorResult(code=exc.code, message=exc.message, data=exc.data))
     # Any other uncaught exception inside method - internal error.
     except Exception as exc:
-        logging.exception(exc)
+        logger.error(traceback.format_exc())
         return Left(InternalErrorResult(str(exc)))
     return result
 
@@ -278,5 +281,5 @@ def dispatch_to_response_pure(
         )
     except Exception as exc:
         # There was an error with the jsonrpcserver library.
-        logging.exception(exc)
+        logger.error(traceback.format_exc())
         return post_process(Left(ServerErrorResponse(str(exc), None)))

--- a/jsonrpcserver/dispatcher.py
+++ b/jsonrpcserver/dispatcher.py
@@ -6,7 +6,6 @@ from inspect import signature
 from itertools import starmap
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Union
 import logging
-import traceback
 
 from oslash.either import Either, Left, Right  # type: ignore
 
@@ -34,7 +33,7 @@ from .utils import compose, make_list
 
 Deserialized = Union[Dict[str, Any], List[Dict[str, Any]]]
 
-logger = logging.getLogger("jsonrpcserver")
+logger = logging.getLogger(__name__)
 
 
 def extract_list(
@@ -136,7 +135,7 @@ def call(request: Request, context: Any, method: Method) -> Result:
         return Left(ErrorResult(code=exc.code, message=exc.message, data=exc.data))
     # Any other uncaught exception inside method - internal error.
     except Exception as exc:
-        logger.error(traceback.format_exc())
+        logger.exception(exc)
         return Left(InternalErrorResult(str(exc)))
     return result
 
@@ -281,5 +280,5 @@ def dispatch_to_response_pure(
         )
     except Exception as exc:
         # There was an error with the jsonrpcserver library.
-        logger.error(traceback.format_exc())
+        logger.exception(exc)
         return post_process(Left(ServerErrorResponse(str(exc), None)))


### PR DESCRIPTION
1. Use custom logger instead of logging.root.
2. logger.error(traceback.format_exc()) for more standard python error formatting as opposed to logger.exception(exc).